### PR TITLE
Update Python print statements for Python 3

### DIFF
--- a/Python/MPL115A2.py
+++ b/Python/MPL115A2.py
@@ -53,6 +53,6 @@ cTemp = (temp - 498) / (-5.35) + 25
 fTemp = cTemp * 1.8 + 32
 
 # Output data to screen
-print ("Pressure : %.2f kPa" %pressure)
-print ("Temperature in Celsius : %.2f C" %cTemp)
-print ("Temperature in Fahrenheit : %.2f F" % fTemp)
+print("Pressure : %.2f kPa" %pressure)
+print("Temperature in Celsius : %.2f C" %cTemp)
+print("Temperature in Fahrenheit : %.2f F" % fTemp)

--- a/Python/MPL115A2.py
+++ b/Python/MPL115A2.py
@@ -53,6 +53,6 @@ cTemp = (temp - 498) / (-5.35) + 25
 fTemp = cTemp * 1.8 + 32
 
 # Output data to screen
-print "Pressure : %.2f kPa" %pressure
-print "Temperature in Celsius : %.2f C" %cTemp
-print "Temperature in Fahrenheit : %.2f F" % fTemp
+print ("Pressure : %.2f kPa" %pressure)
+print ("Temperature in Celsius : %.2f C" %cTemp)
+print ("Temperature in Fahrenheit : %.2f F" % fTemp)


### PR DESCRIPTION
This is a simple fix to allow the Python example to run on modern Python 3. The only change was adding brackets around print statements. Tested with physical module. 